### PR TITLE
fix: correct curvature signal

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -317,7 +317,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       costAtPose(pose.pose.position.x, pose.pose.position.y), linear_vel, sign);
 
     // Apply curvature to angular velocity after constraining linear velocity
-    angular_vel = linear_vel * curvature;
+    angular_vel = linear_vel * sign *curvature;
   }
 
   // Collision checking on this velocity heading


### PR DESCRIPTION
# What I did
<!-- A clear and concise description of what the change does.
If you are fixing an issue, add a sentence as:

resolves #ISSUE_NUMBER

This will automatically close the issue when this PR gets merged.
-->
* Testing the RPP with an Ackermann robot moving backwards the robot was moving directions randomly not following the global path: 
![error](https://user-images.githubusercontent.com/38788618/171050991-4c55c420-839a-4be8-967c-5df8db115031.gif)
 So the point of this PR is to fix the RPP to drive backward correctly. This branch is a temporary fix until we don't move to humble.

# How I did it

Taking a closer look into the RPP at this line https://github.com/brisa-robotics/navigation2/blob/80d7d0a080d7401607fd85216f9c450518e7ed42/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp#L628 the linear_vel is being multiplied by the signal, changing the direction of the curvature at line https://github.com/brisa-robotics/navigation2/blob/80d7d0a080d7401607fd85216f9c450518e7ed42/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp#L333
My solution was to also multiply at line 333 by the sign to revert the multiplication and not messing with the applyConstraints function. The result is:
![correct](https://user-images.githubusercontent.com/38788618/171051567-80f92ef3-fea5-4312-be70-dee5e6399adb.gif)
This updates de diagram using the new sukitas's plc message: https://github.com/brisa-robotics/ros2_windrose_drivers/pull/27

# I am not sure about

# How I tested

# I'm not a dummy, so I've checked these

- [x] 📑 I documented correctly following our [guidelines](https://wiki.brisa.tech/doc/wip-coding-guidelines-taBbXSnHnk)
- [x] 💯 I tested locally and it is working
- [x] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you! ❤️